### PR TITLE
Add https if missing

### DIFF
--- a/o.sh
+++ b/o.sh
@@ -34,6 +34,11 @@ get_url() {
 			fi
 		fi
 
+		# Append protocol if it's missing
+		if [[ $url != "https://"* ]] && [[ $url != "http://"* ]]; then
+			url="https://"$url
+		fi
+
 		echo $url
 	fi
 }


### PR DESCRIPTION
Problem: If the protocol is missing, when trying to open the url it will open the file system (at least in MacOS finder).
I picked to append `https` over `http` because my guess is that it's easier to find repos with ssl rather than without it; not always http is redirected to https.